### PR TITLE
Manually registered pages and resources do not have a context

### DIFF
--- a/src/ContextManager.php
+++ b/src/ContextManager.php
@@ -8,6 +8,7 @@ use Filament\FilamentManager;
 use Filament\Models\Contracts\HasAvatar;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -162,5 +163,21 @@ abstract class ContextManager extends FilamentManager
         $provider = static::getDefaultAvatarProvider() ?? config('filament.default_avatar_provider');
 
         return app($provider)->get($user);
+    }
+
+    public function setResourceContexts()
+    {
+        Log::debug($this->pages);
+
+        foreach ($this->pages as $pageClass) {
+            $pageClass::setContext(static::class);
+        }
+    }
+
+    public function setPageContexts()
+    {
+        foreach ($this->pages as $pageClass) {
+            $pageClass::setContext(static::class);
+        }
     }
 }

--- a/src/FilamentMultiContextManager.php
+++ b/src/FilamentMultiContextManager.php
@@ -37,7 +37,7 @@ class FilamentMultiContextManager
 
     public function registerContexts($contexts): void
     {
-        if (!is_array($contexts)) {
+        if (! is_array($contexts)) {
             $contexts = [$contexts];
         }
 
@@ -46,7 +46,7 @@ class FilamentMultiContextManager
                 $context = new $context();
             }
 
-            if (!is_a($context, ContextManager::class)) {
+            if (! is_a($context, ContextManager::class)) {
                 throw new Exception('Global search provider ' . $context::class . ' is not an instance of ' . ContextManager::class);
             }
 
@@ -86,7 +86,7 @@ class FilamentMultiContextManager
 
     public function context($returnObject = false): null|string|FilamentManager
     {
-        if (is_null($this->context) || !array_key_exists($this->context, $this->contexts)) {
+        if (is_null($this->context) || ! array_key_exists($this->context, $this->contexts)) {
             return $this->filament;
         }
 
@@ -97,7 +97,7 @@ class FilamentMultiContextManager
     {
         $filesystem = app(Filesystem::class);
 
-        if (!$filesystem->exists($context::getResourcesPath())) {
+        if (! $filesystem->exists($context::getResourcesPath())) {
             return;
         }
 
@@ -107,7 +107,7 @@ class FilamentMultiContextManager
                     ->append('\\', $file->getRelativePathname())
                     ->replace(['/', '.php'], ['\\', '']);
             })
-            ->filter(fn (string $class): bool => is_subclass_of($class, Resource::class) && (!(new ReflectionClass($class))->isAbstract()) && in_array(ContextualResource::class, class_uses_recursive($class)))
+            ->filter(fn (string $class): bool => is_subclass_of($class, Resource::class) && (! (new ReflectionClass($class))->isAbstract()) && in_array(ContextualResource::class, class_uses_recursive($class)))
             ->toArray();
 
         $context->registerResources($resources);
@@ -117,7 +117,7 @@ class FilamentMultiContextManager
     {
         $filesystem = app(Filesystem::class);
 
-        if (!$filesystem->exists($context::getPagesPath())) {
+        if (! $filesystem->exists($context::getPagesPath())) {
             return;
         }
 
@@ -127,7 +127,7 @@ class FilamentMultiContextManager
                     ->append('\\', $file->getRelativePathname())
                     ->replace(['/', '.php'], ['\\', '']);
             })
-            ->filter(fn (string $class): bool => is_subclass_of($class, Page::class) && (!(new ReflectionClass($class))->isAbstract()) && in_array(ContextualPage::class, class_uses_recursive($class)))
+            ->filter(fn (string $class): bool => is_subclass_of($class, Page::class) && (! (new ReflectionClass($class))->isAbstract()) && in_array(ContextualPage::class, class_uses_recursive($class)))
             ->toArray();
 
         $context->registerPages($pages);
@@ -137,7 +137,7 @@ class FilamentMultiContextManager
     {
         $filesystem = app(Filesystem::class);
 
-        if (!$filesystem->exists($context::getWidgetsPath())) {
+        if (! $filesystem->exists($context::getWidgetsPath())) {
             return;
         }
 
@@ -147,7 +147,7 @@ class FilamentMultiContextManager
                     ->append('\\', $file->getRelativePathname())
                     ->replace(['/', '.php'], ['\\', '']);
             })
-            ->filter(fn (string $class): bool => is_subclass_of($class, Widget::class) && (!(new ReflectionClass($class))->isAbstract()))
+            ->filter(fn (string $class): bool => is_subclass_of($class, Widget::class) && (! (new ReflectionClass($class))->isAbstract()))
             ->toArray());
     }
 

--- a/tests/ContextManagerTest.php
+++ b/tests/ContextManagerTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use Artificertech\FilamentMultiContext\Tests\Filament\ManuallyRegisteredContext;
+use Artificertech\FilamentMultiContext\Tests\Filament\ManuallyRegisteredContext\ManuallyRegisteredPage;
+use Filament\Facades\Filament;
+
+it('can manually register pages', function () {
+    Filament::getContexts();
+
+    $this->assertEquals(ManuallyRegisteredContext::class, ManuallyRegisteredPage::getContext());
+});

--- a/tests/Filament/ManuallyRegisteredContext.php
+++ b/tests/Filament/ManuallyRegisteredContext.php
@@ -8,6 +8,6 @@ use Artificertech\FilamentMultiContext\Tests\Filament\ManuallyRegisteredContext\
 class ManuallyRegisteredContext extends ContextManager
 {
     protected array $pages = [
-        ManuallyRegisteredPage::class
+        ManuallyRegisteredPage::class,
     ];
 }

--- a/tests/Filament/ManuallyRegisteredContext.php
+++ b/tests/Filament/ManuallyRegisteredContext.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Artificertech\FilamentMultiContext\Tests\Filament;
+
+use Artificertech\FilamentMultiContext\ContextManager;
+use Artificertech\FilamentMultiContext\Tests\Filament\ManuallyRegisteredContext\ManuallyRegisteredPage;
+
+class ManuallyRegisteredContext extends ContextManager
+{
+    protected array $pages = [
+        ManuallyRegisteredPage::class
+    ];
+}

--- a/tests/Filament/ManuallyRegisteredContext/ManuallyRegisteredPage.php
+++ b/tests/Filament/ManuallyRegisteredContext/ManuallyRegisteredPage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Artificertech\FilamentMultiContext\Tests\Filament\ManuallyRegisteredContext;
+
+use Artificertech\FilamentMultiContext\Concerns\ContextualPage;
+use Filament\Pages\Page;
+
+class ManuallyRegisteredPage extends Page
+{
+    use ContextualPage;
+}


### PR DESCRIPTION
Pages and Resources that were manually registered in a context using the $pages or $resources properties did not have the static::$context property set when filament resolves