### PR TITLE
[Draft] [v1.x] Update method signature

### DIFF
--- a/src/ContextManager.php
+++ b/src/ContextManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\AvatarProviders\Contracts\AvatarProvider;
 use Filament\FilamentManager;
 use Filament\Models\Contracts\HasAvatar;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Route;
@@ -147,7 +148,7 @@ abstract class ContextManager extends FilamentManager
         return static::getAuth() ?? auth()->guard(config('filament.auth.guard'));
     }
 
-    public function getUserAvatarUrl(Model $user): string
+    public function getUserAvatarUrl(Model|Authenticable $user): string
     {
         $avatar = null;
 


### PR DESCRIPTION
The latest Filament version has update `getUserAvatarUrl`.

This is a minor fix. I hope this can be release in v1.x channel as a patch in the meantime the 2.x is in beta.

This cloud be merged in a `v1.x` branch starting from commit `e30aabc2a870d6256200644c6a3a2f39bfb39739`.