### PR TITLE
🐛 Should register context livewire compnent aliases

### DIFF
--- a/src/ContextServiceProvider.php
+++ b/src/ContextServiceProvider.php
@@ -22,6 +22,8 @@ use Symfony\Component\Finder\SplFileInfo;
 
 abstract class ContextServiceProvider extends PluginServiceProvider
 {
+    protected array $livewireComponents = [];
+
     public function packageRegistered(): void
     {
         $this->app->booting(function () {
@@ -82,7 +84,7 @@ abstract class ContextServiceProvider extends PluginServiceProvider
         parent::packageBooted();
 
         Filament::setContext();
-        
+
         $this->bootLivewireComponents();
     }
 

--- a/src/ContextServiceProvider.php
+++ b/src/ContextServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Livewire\Component;
+use Livewire\Livewire;
 use ReflectionClass;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -81,6 +82,8 @@ abstract class ContextServiceProvider extends PluginServiceProvider
         parent::packageBooted();
 
         Filament::setContext();
+        
+        $this->bootLivewireComponents();
     }
 
     protected function registerComponents(): void
@@ -199,5 +202,12 @@ abstract class ContextServiceProvider extends PluginServiceProvider
     protected function contextConfig(string $key, string $default = null)
     {
         return Arr::get(config(static::$name), $key, $default);
+    }
+
+    protected function bootLivewireComponents(): void
+    {
+        foreach ($this->livewireComponents as $alias => $class) {
+            Livewire::component($alias, $class);
+        }
     }
 }

--- a/tests/FilamentTeamsTest.php
+++ b/tests/FilamentTeamsTest.php
@@ -7,7 +7,6 @@ use Artificertech\FilamentMultiContext\Tests\App\FilamentTeams\Resources\UserRes
 use Artificertech\FilamentMultiContext\Tests\App\Models\User;
 use Filament\Facades\Filament;
 use Livewire\Livewire;
-
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 

--- a/tests/FilamentTeamsTest.php
+++ b/tests/FilamentTeamsTest.php
@@ -2,9 +2,12 @@
 
 use Artificertech\FilamentMultiContext\Tests\App\FilamentTeams\Pages\Dashboard;
 use Artificertech\FilamentMultiContext\Tests\App\FilamentTeams\Resources\UserResource;
+use Artificertech\FilamentMultiContext\Tests\App\FilamentTeams\Resources\UserResource\Pages\CreateUser;
 use Artificertech\FilamentMultiContext\Tests\App\FilamentTeams\Resources\UserResource\RelationManagers\PostsRelationManager;
 use Artificertech\FilamentMultiContext\Tests\App\Models\User;
 use Filament\Facades\Filament;
+use Livewire\Livewire;
+
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 
@@ -29,6 +32,14 @@ it('registers filament-teams resources', function () {
     get(route('filament-teams.resources.teams-users.index'))
         ->assertSuccessful();
 });
+
+it('registers filament-teams livewire component aliases', function () {
+    Filament::forContext('filament-teams', function () {
+        $createUserAliases = array_keys(Livewire::getComponentAliases(), CreateUser::class);
+
+        expect($createUserAliases)->toContain('filament-teams.resources.user-resource.pages.create-user');
+    });
+})->only();
 
 it('registers filament-teams relation managers', function () {
     actingAs($user = User::factory()->hasPosts(3)->create());

--- a/tests/FilamentTeamsTest.php
+++ b/tests/FilamentTeamsTest.php
@@ -38,7 +38,7 @@ it('registers filament-teams livewire component aliases', function () {
 
         expect($createUserAliases)->toContain('filament-teams.resources.user-resource.pages.create-user');
     });
-})->only();
+});
 
 it('registers filament-teams relation managers', function () {
     actingAs($user = User::factory()->hasPosts(3)->create());


### PR DESCRIPTION
This PR aims to match `ContextServiceProvider`'s behavior with `Filament\FilamentServiceProvider` where the later [registers Livewire components aliases](https://github.com/filamentphp/filament/blob/f54b6edb54d66dd408285d7097249e1091c78e6e/packages/admin/src/FilamentServiceProvider.php#L247-L262).

When dumping `Livewire::getComponentAliases()` in the tests:

![filamentmulticontext before](https://user-images.githubusercontent.com/21353103/197516886-4f91efe2-d463-4c3c-b993-781d556adcaf.png)

Notice that:
- `Artificertech\FilamentMultiContext\Tests\App\Filament\Resources\UserResource\Pages\ListUsers` is aliased as:
    - `artificertech.filament-multi-context.tests.app.filament.resources.user-resource.pages.list-users`
    - `filament.resources.user-resource.pages.list-users` 
- `Artificertech\FilamentMultiContext\Tests\App\FilamentTeams\Resources\UserResource\Pages\ListUsers` is only aliased as: 
    - `artificertech.filament-multi-context.tests.app.filament-teams.resources.user-resource.pages.list-users`

Now in this PR, observe that `Artificertech\FilamentMultiContext\Tests\App\FilamentTeams\Resources\UserResource\Pages\ListUsers` is aliased twice:

![filamentmulticontext after](https://user-images.githubusercontent.com/21353103/197517591-a25b9005-6f2d-4537-80b1-1d94b5366cb8.png)

----

This is particularly useful when developers have custom livewire components residing in `FilamentTeams/Livewire`. They'll no longer need to register an alias for them as we are automatically aliasing it for them.
