### PR TITLE
👽️ Sync `ContextServiceProvider::packageRegistered()` behavior with parent class

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ are:
 Your `ContextServiceProvider` found in your
 `app/Providers/FilamentTeamsServiceProvider.php` is an extension of the Filament
 `PluginServiceProvder` so features of the `PluginServiceProvider` may be used
-for your context
+for your context. Any UserMenuItems, scripts, styles, or scriptData added to
+the provider will be registered for that context only
 
 ### Custom Page and Resource Routing
 
@@ -166,7 +167,7 @@ Filament::getContexts()
 ```
 
 ```php
-// set the current app context. 
+// set the current app context.
 // Passing null or nothing sets the context to 'filament'
 
 Filament::setContext(string|null $context)
@@ -180,8 +181,8 @@ Filament::forContext(string $context, function () {
 ```
 
 ```php
-// loops through each registered context (including the default 'filament' context), 
-// sets that context as the current context, 
+// loops through each registered context (including the default 'filament' context),
+// sets that context as the current context,
 // runs the callback, then resets to the original value
 Filament::forAllContexts(function () {
     // ...

--- a/src/ContextServiceProvider.php
+++ b/src/ContextServiceProvider.php
@@ -36,6 +36,10 @@ abstract class ContextServiceProvider extends PluginServiceProvider
                 Facades\Filament::registerWidgets($this->getWidgets());
 
                 Facades\Filament::serving(function () {
+                    if (Filament::currentContext() !== static::$name) {
+                        return;
+                    }
+
                     Facades\Filament::registerUserMenuItems($this->getUserMenuItems());
                     Facades\Filament::registerScripts($this->getBeforeCoreScripts(), true);
                     Facades\Filament::registerScripts($this->getScripts());

--- a/src/ContextServiceProvider.php
+++ b/src/ContextServiceProvider.php
@@ -34,6 +34,14 @@ abstract class ContextServiceProvider extends PluginServiceProvider
                 Facades\Filament::registerPages($this->getPages());
                 Facades\Filament::registerResources($this->getResources());
                 Facades\Filament::registerWidgets($this->getWidgets());
+
+                Facades\Filament::serving(function () {
+                    Facades\Filament::registerUserMenuItems($this->getUserMenuItems());
+                    Facades\Filament::registerScripts($this->getBeforeCoreScripts(), true);
+                    Facades\Filament::registerScripts($this->getScripts());
+                    Facades\Filament::registerStyles($this->getStyles());
+                    Facades\Filament::registerScriptData($this->getScriptData());
+                });
             });
         });
     }


### PR DESCRIPTION
This PR aims to sync `ContextServiceProvider::packageRegistered()`'s behaviour with `Filament\PluginServiceProvider` where the later [registers scripts, styles, etc.](https://github.com/filamentphp/filament/blob/d87914e3b585be268c38c87df6eb547f1f6aaaca/packages/admin/src/PluginServiceProvider.php#L68-L74
)