### PR TITLE
📌 Loosen up Filament version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "filament/filament": "^2.15.16|^2.16",
+        "filament/filament": "^2.15.16",
         "illuminate/contracts": "^8.6|^9.0|^10.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },


### PR DESCRIPTION
This PR aims to open the filament version constraint. We were unable to upgrade to Filament v2.17 before.